### PR TITLE
Add automated package build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Apt packages
+        id: cache-apt
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          execute_install_scripts: true
+          packages: libarchive-tools
+          version: 1.0
+      - name: Get package
+        run: |
+          curl -s "$url" -o package
+          sed -i \
+            "s/~VERSION~/~r${sha}.${run_number}-${run_attempt}/" \
+            ./package
+          sed -i \
+            "s|~REPOSITORY~|${repository}|" \
+            ./package
+          sed -i \
+            "s|~SHA~|${sha}|" \
+            ./package
+        env:
+          url: "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/package"
+          sha: ${{ github.sha }}
+          run_number: ${{ github.run_number }}
+          run_attempt: ${{ github.run_attempt }}
+          repository: ${{ github.repository }}
+      - name: Build package
+        uses: toltec-dev/build-action@v1
+      - name: Save packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/**/*.ipk

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ modules.order
 !.gitattributes
 !.gitignore
 !.mailmap
+!.github/
 
 #
 # Generated include files

--- a/package
+++ b/package
@@ -1,0 +1,75 @@
+archs=(rm1 rm2)
+pkgnames=(linux-stracciatella)
+pkgdesc="RemarkableAS's vanilla kernel with a few extra flakes"
+url=https://github.com/Etn40ff/linux-remarkable
+pkgver="5.4.70~VERSION~"
+timestamp=2023-09-23T00:12:00Z
+section="kernel"
+maintainer="Salvatore Stella <etn45p4m@gmail.com>"
+makedepends=(build:flex build:bison build:libssl-dev build:bc build:lzop build:libgmp-dev build:libmpc-dev build:kmod)
+license=GPL-2.0-only
+flags=(nostrip)
+installdepends=(kernelctl)
+image=base:v3.1
+_wireguard_version=1.0.20220627
+source=(
+    "https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$_wireguard_version.tar.xz"
+    "https://github.com/~REPOSITORY~/archive/~SHA~.tar.gz"
+)
+sha256sums=(
+    362d412693c8fe82de00283435818d5c5def7f15e2433a07a9fe99d0518f63c0
+    SKIP
+)
+noextract=("wireguard-linux-compat-$_wireguard_version.tar.xz")
+
+prepare() {
+    # Jury-rig the wireguard module into sources and enable it
+    mkdir "$srcdir/net/wireguard"
+    bsdtar --strip-components 2 -xJ -C "$srcdir/net/wireguard" \
+        -f "$srcdir/wireguard-linux-compat-$_wireguard_version.tar.xz" \
+        "wireguard-linux-compat-$_wireguard_version/src"
+    sed -i "/^obj-\\\$(CONFIG_NETFILTER).*+=/a obj-\$(CONFIG_WIREGUARD) += wireguard/" "$srcdir/net/Makefile"
+    sed -i "/^if INET\$/a source \"net/wireguard/Kconfig\"" "$srcdir/net/Kconfig"
+    echo "CONFIG_WIREGUARD=m" >> "$srcdir/arch/arm/configs/zero-gravitas_defconfig"
+    echo "CONFIG_WIREGUARD=m" >> "$srcdir/arch/arm/configs/zero-sugar_defconfig"
+}
+
+build() {
+    if [[ $arch = rm1 ]]; then
+        ARCH=arm make zero-gravitas_defconfig
+    elif [[ $arch = rm2 ]]; then
+        ARCH=arm make zero-sugar_defconfig
+    fi
+    ARCH=arm make -j8
+}
+
+package() {
+    # Prepare files for the kernel archive
+    local staging="$srcdir"/staging
+    mkdir -p "$staging/boot"
+
+    cp --no-dereference {"$srcdir"/arch/arm,"$staging"}/boot/zImage
+    if [[ $arch = rm1 ]]; then
+        cp --no-dereference "$srcdir"/arch/arm/boot/dts/zero-gravitas.dtb "$staging"/boot/zero-gravitas.dtb
+    elif [[ $arch = rm2 ]]; then
+        cp --no-dereference "$srcdir"/arch/arm/boot/dts/zero-sugar.dtb "$staging"/boot/zero-sugar.dtb
+    fi
+
+    ARCH=arm make -C "$srcdir" modules_install INSTALL_MOD_PATH="$staging"
+    rm "$staging"/lib/modules/*/{source,build}
+
+    # Create the kernel archive
+    local archive="stracciatella-${pkgver%-*}.tar.bz2"
+    install -d "$pkgdir"/opt/usr/share/kernelctl
+    (cd "$staging" && tar --owner root:0 --group root:0 --mtime=$timestamp \
+        -cjf "$pkgdir"/opt/usr/share/kernelctl/"$archive" boot/* lib/modules/*)
+}
+
+configure() {
+    if [[ $(< /etc/version) -le 20210709090000 ]]; then
+        echo "WARNING: Your system is too old; this kernel will most likely not work unless you add the appropriate firmware blobs to /lib/firmware."
+        echo "Please consider updating your system instead."
+    fi
+    echo "The new kernel files have been copied, but not installed."
+    echo "Please use kernelctl to select the kernel to boot."
+}

--- a/package-exclude.txt
+++ b/package-exclude.txt
@@ -1,0 +1,4 @@
+./package
+./package-exclude.txt
+./.github/
+./src.tar.gz


### PR DESCRIPTION
1. The workflow installs `libarchive-tools` as the current package command requires bsdtar
2. The workflow downloads just the `package` file for the current commit and updates the package version, and source URL
   - Package version will be generated with the following: `5.4.70~r{sha}.{run_number}-{run_attempt}`
     - sha is the git sha for the commit
     - run_number is the count of runs of the workflow, starting at 1
     - run_attempt is the count of attempts a specific workflow run has had, which is useful if you have to reattempt a build due to a bad external dependency or something
4. Package is built using toltecmk
5. Packages are uploaded as an artifact